### PR TITLE
remove dependency on btw

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,6 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Imports: 
-    btw (>= 0.0.1.9000),
     cli,
     ellmer (>= 0.2.0),
     jsonlite,
@@ -37,6 +36,4 @@ Depends: R (>= 4.1.0)
 URL: https://github.com/posit-dev/acquaint, https://posit-dev.github.io/acquaint/
 BugReports: https://github.com/posit-dev/acquaint/issues
 Config/Needs/website: tidyverse/tidytemplate
-Remotes:
-    posit-dev/btw
 VignetteBuilder: knitr

--- a/R/server.R
+++ b/R/server.R
@@ -3,7 +3,8 @@
 # response, it will print the response to stdout.
 #' @param tools A list of tools created with [ellmer::tool()] that will be
 #' available from the server. Any list that could be passed to `Chat$set_tools()`
-#' can be passed here. By default, the package will use [btw::btw_tools()].
+#' can be passed here. By default, the package won't serve any tools other
+#' than those needed to communicate with active R sessions.
 #'
 #' @rdname mcp
 #' @export
@@ -12,10 +13,7 @@
 #' # should only be run non-interactively, and will block the current R process
 #' # once called.
 #' if (FALSE) {
-#' # to just start a server with btw tools:
-#' mcp_server()
-#'
-#' # to do so with non-default tools:
+#' # to start a server with a tool to draw numbers from a random normal:
 #' library(ellmer)
 #'
 #' tool_rnorm <- tool(
@@ -28,7 +26,7 @@
 #'
 #' mcp_server(tools = list(tool_rnorm))
 #' }
-mcp_server <- function(tools = btw::btw_tools()) {
+mcp_server <- function(tools = NULL) {
   # TODO: should this actually be a check for being called within Rscript or not?
   check_not_interactive()
   set_server_tools(tools)

--- a/R/tools.R
+++ b/R/tools.R
@@ -1,4 +1,8 @@
 set_server_tools <- function(x, call = caller_env()) {
+  if (is.null(x)) {
+    the$server_tools <- c(list(list_r_sessions_tool, select_r_session_tool))
+    return()
+  }
   if (!is_list(x) || !all(vapply(x, inherits, logical(1), "ellmer::ToolDef"))) {
     msg <- "{.arg x} must be a list of tools created with {.fn ellmer::tool}."
     if (inherits(x, "ellmer::ToolDef")) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -21,7 +21,7 @@ knitr::opts_chunk$set(
 [![R-CMD-check](https://github.com/simonpcouch/acquaint/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/simonpcouch/acquaint/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
-acquaint implements a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server for your R sessions. When configured with acquaint, MCP-enabled tools like Claude Desktop and Claude Code can run R code _in the sessions you have running_ to answer your questions. While the package supports configuring arbitrary R functions, acquaint provides a default set of tools [from btw](https://posit-dev.github.io/btw/) to:
+acquaint implements a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server for your R sessions. When configured with acquaint, MCP-enabled tools like Claude Desktop and Claude Code can run R code _in the sessions you have running_ to answer your questions. The package supports configuring arbitrary R functions, though you may be interested in the [btw](https://posit-dev.github.io/btw/) package's integrated support for acquaint, which provides a default set of tools to:
 
 * Peruse the documentation of packages you have installed,
 * Check out the objects in your global environment, and

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ acquaint implements a [Model Context
 Protocol](https://modelcontextprotocol.io/) (MCP) server for your R
 sessions. When configured with acquaint, MCP-enabled tools like Claude
 Desktop and Claude Code can run R code *in the sessions you have
-running* to answer your questions. While the package supports
-configuring arbitrary R functions, acquaint provides a default set of
-tools [from btw](https://posit-dev.github.io/btw/) to:
+running* to answer your questions. The package supports configuring
+arbitrary R functions, though you may be interested in the
+[btw](https://posit-dev.github.io/btw/) package’s integrated support for
+acquaint, which provides a default set of tools to:
 
 - Peruse the documentation of packages you have installed,
 - Check out the objects in your global environment, and

--- a/man/mcp.Rd
+++ b/man/mcp.Rd
@@ -6,14 +6,15 @@
 \alias{mcp_session}
 \title{Model context protocol for your R session}
 \usage{
-mcp_server(tools = btw::btw_tools())
+mcp_server(tools = NULL)
 
 mcp_session()
 }
 \arguments{
 \item{tools}{A list of tools created with \code{\link[ellmer:tool]{ellmer::tool()}} that will be
 available from the server. Any list that could be passed to \code{Chat$set_tools()}
-can be passed here. By default, the package will use \code{\link[btw:btw_tools]{btw::btw_tools()}}.}
+can be passed here. By default, the package won't serve any tools other
+than those needed to communicate with active R sessions.}
 }
 \description{
 Together, these functions implement a model context protocol server for your
@@ -55,10 +56,7 @@ available to the server.
 # should only be run non-interactively, and will block the current R process
 # once called.
 if (FALSE) {
-# to just start a server with btw tools:
-mcp_server()
-
-# to do so with non-default tools:
+# to start a server with a tool to draw numbers from a random normal:
 library(ellmer)
 
 tool_rnorm <- tool(

--- a/vignettes/acquaint.Rmd
+++ b/vignettes/acquaint.Rmd
@@ -52,7 +52,7 @@ While a single client and a single R session probably covers many users' use cas
 
 ## Custom tools
 
-By default, acquaint supplies clients with `btw::btw_tools()`, a set of atomic tools for data science from [the btw package](https://posit-dev.github.io/btw). These tools allow clients to:
+By default, acquaint supplies clients with only the necessary infrastructural tools to implement interaction with active sessions. You may be interested in using acquaint via [btw's wrappers](https://posit-dev.github.io/btw), which provide a set of atomic tools for data science. These tools allow clients to:
 
 -   Peruse package documentation
 
@@ -68,5 +68,3 @@ Users might be interested in extending these tools or supplying completely diffe
 You can configure any set of tools that could be passed to the `$set_tools()` method of an ellmer Chat object as the tools that acquaint will supply to clients. To do so, supply a list of outputs from `ellmer::tool()` to the `tools` argument of `mcp_server()`. Relatedly, you'll need to make sure that your code that specifies the new tools can run in a fresh R session; be sure to either namespace functions from libraries (like `ellmer::tool()` instead of `tool()`) or load the libraries entirely.
 
 <!--# \[TODO: provide an example of registering the `rnorm()` tool.\] -->
-
-Note that, if you'd like to supply some custom tools *in addition to* the default tools from btw, you'll need to set `tools = (c(btw::btw_tools(), your_custom_tools))`.


### PR DESCRIPTION
Related to #35 but does not close. A companion PR with https://github.com/posit-dev/btw/pull/73.

In this PR, acquaint "forgets about" btw and only implements the protocol serves the two needed tools to communicate with sessions by default:

<img width="334" alt="Screenshot 2025-06-20 at 2 36 24 PM" src="https://github.com/user-attachments/assets/7a2fa0a4-81ea-4d09-98ca-654819f69ee7" />

The preferred entry point to a batteries-included "R MCP server" then becomes the one exported by btw. Will link more directly in docs once the naming is solidified.